### PR TITLE
fix: remove self-referencing .gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .DS_Store
 target
-.gitignore


### PR DESCRIPTION
The .gitignore file was ignoring itself, causing release-plz to fail with "uncommitted changes" errors since tracked files matched gitignore patterns.