### PR TITLE
chore: release v1.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.22.1](https://github.com/security-union/yew-websocket/compare/v1.22.0...v1.22.1) - 2026-02-09
+
+### Fixed
+
+- remove self-referencing .gitignore entry ([#19](https://github.com/security-union/yew-websocket/pull/19))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "yew-websocket"
-version = "1.22.0"
+version = "1.22.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-websocket"
-version = "1.22.0"
+version = "1.22.1"
 edition = "2021"
 license = "MIT"
 publish = true


### PR DESCRIPTION



## 🤖 New release

* `yew-websocket`: 1.22.0 -> 1.22.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.22.1](https://github.com/security-union/yew-websocket/compare/v1.22.0...v1.22.1) - 2026-02-09

### Fixed

- remove self-referencing .gitignore entry ([#19](https://github.com/security-union/yew-websocket/pull/19))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).